### PR TITLE
Failing to set SO_REUSEADDR is not a fatal error

### DIFF
--- a/Sources/ARCONTROLLER_Network.c
+++ b/Sources/ARCONTROLLER_Network.c
@@ -101,8 +101,7 @@ static int ARCONTROLLER_Network_GetAvailableSocketPort(void)
     yes = 1;
     ret = ARSAL_Socket_Setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
     if (ret < 0) {
-        ARSAL_PRINT(ARSAL_PRINT_ERROR, ARCONTROLLER_NETWORK_TAG, "Failed to set socket option SO_REUSEADDR: error=%d (%s)", errno, strerror(errno));
-        goto error;
+        ARSAL_PRINT(ARSAL_PRINT_WARNING, ARCONTROLLER_NETWORK_TAG, "Failed to set socket option SO_REUSEADDR: error=%d (%s)", errno, strerror(errno));
     }
 
     ARSAL_PRINT(ARSAL_PRINT_INFO, ARCONTROLLER_NETWORK_TAG, "d2c_port port: %d", htons(addr.sin_port));

--- a/Sources/ARCONTROLLER_Stream2.c
+++ b/Sources/ARCONTROLLER_Stream2.c
@@ -115,8 +115,7 @@ static int ARCONTROLLER_Stream2_Open_Socket(const char *name, int *sockfd, int *
     yes = 1;
     ret = ARSAL_Socket_Setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
     if (ret < 0) {
-        ARSAL_PRINT(ARSAL_PRINT_ERROR, ARCONTROLLER_STREAM2_TAG, "Failed to set socket option SO_REUSEADDR: error=%d (%s)", errno, strerror(errno));
-        goto error;
+        ARSAL_PRINT(ARSAL_PRINT_WARNING, ARCONTROLLER_STREAM2_TAG, "Failed to set socket option SO_REUSEADDR: error=%d (%s)", errno, strerror(errno));
     }
 
     ARSAL_PRINT(ARSAL_PRINT_INFO, ARCONTROLLER_STREAM2_TAG, "udp local port %s: %d", name, htons(addr.sin_port));


### PR DESCRIPTION
Library can still run perfectly fine without setting this option.

Needed because Windows Subsystem for Linux (WSL) does not yet support this option.